### PR TITLE
NTBS-2693 Display backfilled transfer audit logs

### DIFF
--- a/ntbs-service/Services/NotificationChangesService.cs
+++ b/ntbs-service/Services/NotificationChangesService.cs
@@ -197,8 +197,8 @@ namespace ntbs_service.Services
                && group.All(log => log.EntityType == nameof(TreatmentEvent))
                && group.All(log => log.EventType == "Insert")
                && group.All(log => log.AuditDetails == "SystemEdited")
-               && group.Any(log => log.AuditData.Contains("\"TreatmentEventType\":\"TransferIn\""))
-               && group.Any(log => log.AuditData.Contains("\"TreatmentEventType\":\"TransferOut\"")))
+               && group.Any(log => log.AuditData.Contains("TransferIn"))
+               && group.Any(log => log.AuditData.Contains("TransferOut")))
             {
                 // We only need one log for the pair
                 var log = group.First();


### PR DESCRIPTION
## Description
The transfer audit logs are alert-centric, allowing us to say who accepted the transfer. This does not make sense for backfilled transfers which should show up as a single edit made by the system. Edit audit log grouping to allow for this.

I don't like this very much but I think this is the best approach. After a thinking a bit more, the idea of a general backfill audit type is not as good as I first thought, because you would lose the ability to know exactly what has been modified by the backfill (whereas this approach will show the table edited)

![image](https://user-images.githubusercontent.com/3650110/136368827-8c9ca0af-de7c-4ec9-98a5-526674f2971d.png)

## Checklist:
- [x] Automated tests are passing locally.