### PR TITLE
NTBS-2767: Show case manager in legacy notifications

### DIFF
--- a/ntbs-service/Services/LegacySearchService.cs
+++ b/ntbs-service/Services/LegacySearchService.cs
@@ -42,6 +42,8 @@ namespace ntbs_service.Services
                      n.NotificationDate,
                      n.PrimarySource,
                      n.NtbsHospitalId,
+                     lu.GivenName AS CaseManagerGivenName,
+                     lu.FamilyName AS CaseManagerFamilyName,
                      dmg.NtbsSexId,
                      dmg.GivenName,
                      dmg.FamilyName,
@@ -56,6 +58,7 @@ namespace ntbs_service.Services
             FROM MergedNotifications n 
             LEFT JOIN Addresses addrs ON addrs.OldNotificationId = n.PrimaryNotificationId
             LEFT JOIN Demographics dmg ON dmg.OldNotificationId = n.PrimaryNotificationId
+            LEFT JOIN LegacyUser lu ON lu.Username = n.CaseManager
             WHERE NOT EXISTS ({_notificationImportHelper.SelectImportedNotificationWhereIdEquals("n.PrimaryNotificationId")})
             ";
 
@@ -167,6 +170,8 @@ namespace ntbs_service.Services
                 TbService = tbService?.Name,
                 TbServiceCode = tbService?.Code,
                 TbServicePHECCode = tbService?.PHECCode,
+                // Currently it is never the case that given name exists and family name doesn't or vice versa.
+                CaseManager = result.CaseManagerGivenName != null ? $"{result.CaseManagerGivenName} {result.CaseManagerFamilyName}" : null,
                 LocationPHECCode = locationPhecCode,
                 Postcode = (result.Postcode as string).FormatStringToPostcodeFormat(),
                 NhsNumber = (result.NhsNumber as string).FormatStringToNhsNumberFormat(),


### PR DESCRIPTION
## Description
Now show the case manager in the banner for legacy notifications. 
At the moment I'm using LegacyUser which is a view, but I think I should materialise this into a table so we can use that for performance. I'll make a PR in the migration repo to do that, and if we don't feel like it's needed we won't merge.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
- [x] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
