### PR TITLE
NTBS-NONE Resolve security alert by upgrading webpack-hot-middleware

### DIFF
--- a/ntbs-service/package-lock.json
+++ b/ntbs-service/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ntbs-service",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -40,7 +39,7 @@
         "webpack": "5.51.1",
         "webpack-cli": "4.8.0",
         "webpack-dev-middleware": "5.2.1",
-        "webpack-hot-middleware": "2.25.0",
+        "webpack-hot-middleware": "2.25.1",
         "webpack-merge": "5.8.0"
       }
     },
@@ -2033,10 +2032,10 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+    "node_modules/ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true,
       "engines": [
         "node >= 0.8.0"
@@ -2902,9 +2901,9 @@
       "dev": true
     },
     "node_modules/html-entities": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
-      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
       "dev": true
     },
     "node_modules/https-proxy-agent": {
@@ -4656,15 +4655,36 @@
       }
     },
     "node_modules/webpack-hot-middleware": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.0.tgz",
-      "integrity": "sha512-xs5dPOrGPCzuRXNi8F6rwhawWvQQkeli5Ro48PRuQh8pYPCPmNnltP9itiUPT4xI8oW+y0m59lyyeQk54s5VgA==",
+      "version": "2.25.1",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.1.tgz",
+      "integrity": "sha512-Koh0KyU/RPYwel/khxbsDz9ibDivmUbrRuKSSQvW42KSDdO4w23WI3SkHpSUKHE76LrFnnM/L7JCrpBwu8AXYw==",
       "dev": true,
       "dependencies": {
-        "ansi-html": "0.0.7",
-        "html-entities": "^1.2.0",
+        "ansi-html-community": "0.0.8",
+        "html-entities": "^2.1.0",
         "querystring": "^0.2.0",
-        "strip-ansi": "^3.0.0"
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "node_modules/webpack-hot-middleware/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/webpack-hot-middleware/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/webpack-merge": {
@@ -6261,10 +6281,10 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "requires": {}
     },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+    "ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true
     },
     "ansi-regex": {
@@ -6883,9 +6903,9 @@
       "dev": true
     },
     "html-entities": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
-      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
       "dev": true
     },
     "https-proxy-agent": {
@@ -8167,15 +8187,32 @@
       }
     },
     "webpack-hot-middleware": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.0.tgz",
-      "integrity": "sha512-xs5dPOrGPCzuRXNi8F6rwhawWvQQkeli5Ro48PRuQh8pYPCPmNnltP9itiUPT4xI8oW+y0m59lyyeQk54s5VgA==",
+      "version": "2.25.1",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.1.tgz",
+      "integrity": "sha512-Koh0KyU/RPYwel/khxbsDz9ibDivmUbrRuKSSQvW42KSDdO4w23WI3SkHpSUKHE76LrFnnM/L7JCrpBwu8AXYw==",
       "dev": true,
       "requires": {
-        "ansi-html": "0.0.7",
-        "html-entities": "^1.2.0",
+        "ansi-html-community": "0.0.8",
+        "html-entities": "^2.1.0",
         "querystring": "^0.2.0",
-        "strip-ansi": "^3.0.0"
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "webpack-merge": {

--- a/ntbs-service/package.json
+++ b/ntbs-service/package.json
@@ -47,7 +47,7 @@
     "webpack": "5.51.1",
     "webpack-cli": "4.8.0",
     "webpack-dev-middleware": "5.2.1",
-    "webpack-hot-middleware": "2.25.0",
+    "webpack-hot-middleware": "2.25.1",
     "webpack-merge": "5.8.0"
   }
 }


### PR DESCRIPTION
This should be a very minor change - the only change to the `webpack-hot-middleware` package is that a dependency has changed to avoid a particularly inefficient regex.
